### PR TITLE
Add __mocks__ folder to ignorePatterns

### DIFF
--- a/base.js
+++ b/base.js
@@ -106,6 +106,7 @@ const config = {
     '**/*.config.cjs',
     '**/.eslintrc.cjs',
     'dist',
+    '**/__mocks__/**',
     'pnpm-lock.yaml'
   ],
   reportUnusedDisableDirectives: true,


### PR DESCRIPTION
## Changes
- Added the `__mocks__` folder to `ignorePatterns` in order to avoid an ESLint error when specifying how Jest should handle CSS files. This change resolves an issue where Jest was encountering problems processing CSS imports.

### Reference

- [SyntaxError with Jest and React and importing CSS files](https://stackoverflow.com/questions/39418555/syntaxerror-with-jest-and-react-and-importing-css-files)
- [Flex PR](https://github.com/PJNube/flex/pull/53)
