### PR TITLE
Disable @typescript-eslint/require-await and require-await

### DIFF
--- a/base.js
+++ b/base.js
@@ -57,7 +57,8 @@ const config = {
         ignoreReadBeforeAssign: false
       }
     ],
-    'require-await': 'error',
+    '@typescript-eslint/require-await': 'off',
+    'require-await': 'off',
     semi: ['error', 'always'],
     'space-before-blocks': 'error',
     'spaced-comment': ['error', 'always'],


### PR DESCRIPTION
This PR disables the `@typescript-eslint/require-await` and `require-await` rules.

### Reason

We follow an OOP pattern where interfaces may return promises, but not all implementations require await. Enforcing this rule forces unnecessary `Promise.resolve()` calls, making the code less clean. Disabling it allows for flexibility in implementations without redundant code.